### PR TITLE
Always include the entry point

### DIFF
--- a/extensions/roc-plugin-mocha-webpack/src/actions/webpack.js
+++ b/extensions/roc-plugin-mocha-webpack/src/actions/webpack.js
@@ -23,6 +23,11 @@ export default ({ context: { config: { settings }, directory } }) => () => (webp
 
     newWebpackConfig.entry[newWebpackConfig.rocMetaInfo.outputName] = require.resolve(entry);
 
+    // Always include the entry point
+    newWebpackConfig.externals.unshift({
+        [require.resolve(entry)]: false,
+    });
+
     newWebpackConfig.resolve.alias = {
         ...newWebpackConfig.resolve.alias,
         src: join(directory, settings.test.node.src.path),


### PR DESCRIPTION
This solves an issue where it would not be included and the test fails because of that.
