### PR TITLE
Update nyc to latest version

### DIFF
--- a/extensions/roc-plugin-mocha-webpack/package.json
+++ b/extensions/roc-plugin-mocha-webpack/package.json
@@ -31,7 +31,7 @@
     "expect": "~1.20.0",
     "micromatch": "~2.3.8",
     "mocha": "~2.4.5",
-    "nyc": "~6.4.4",
+    "nyc": "~10.1.2",
     "rimraf": "~2.5.2",
     "roc": "^1.0.0-rc.12",
     "roc-abstract-plugin-test": "^1.0.0-beta.2",


### PR DESCRIPTION
Older version of nyc creates invalid Cobertura reports