### PR TITLE
Throw errors from compiler.run|watch

### DIFF
--- a/extensions/roc-plugin-mocha-webpack/src/nyc/index.js
+++ b/extensions/roc-plugin-mocha-webpack/src/nyc/index.js
@@ -25,6 +25,10 @@ const getCommand = (artifact, grep, coverage) => (coverage ?
 const cleanupCoverage = () => rimraf.sync(path.join(process.cwd(), '.nyc_output'));
 
 function getArtifact(compiler, err, stats) {
+    if (err) {
+        throw err;
+    }
+
     const statsJson = stats.toJson();
 
     if (statsJson.errors.length > 0 || statsJson.warnings.length > 0) {


### PR DESCRIPTION
These would previously go unchecked, causing `stats.toJson()` to crash because `stats` is `undefined`. Now we get nicer errors:

```
3 	+ npm -s run test
4 	Found a local version of Roc, will use that over the global one. 
5 	
6 	/usr/src/app/node_modules/roc-plugin-test-mocha-webpack/lib/nyc/index.js:46
7 	        throw err;
8 	        ^
9 	
10 	Error: EACCES: permission denied, open '/usr/src/app/build/server/b773d67a2ee5afd196fe87e3284e61f3.png'
11 	    at Error (native)
```